### PR TITLE
Handle environments with multiple NuSeal versions

### DIFF
--- a/src/NuSeal/Assets.cs
+++ b/src/NuSeal/Assets.cs
@@ -6,7 +6,7 @@ namespace NuSeal;
 
 internal class Assets
 {
-    private const string TASK_NAME = nameof(ValidateLicenseTask);
+    private const string TASK_NAME = nameof(ValidateLicenseTask_0_4_0);
 
     public static string GenerateProps(ConsumerParameters parameters)
     {

--- a/src/NuSeal/Tasks/GenerateConsumerAssetsTask.cs
+++ b/src/NuSeal/Tasks/GenerateConsumerAssetsTask.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 

--- a/src/NuSeal/Tasks/ValidateLicenseTask_0_4_0.cs
+++ b/src/NuSeal/Tasks/ValidateLicenseTask_0_4_0.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace NuSeal;
 
-public partial class ValidateLicenseTask : Task
+public partial class ValidateLicenseTask_0_4_0 : Task
 {
     public string MainAssemblyPath { get; set; } = "";
     public string ProtectedPackageId { get; set; } = "";
@@ -26,7 +26,7 @@ public partial class ValidateLicenseTask : Task
         {
             // This should never happen as we always pass all arguments while preparing assets for authors.
             // If that's the case, something went really wrong, and we won't break end users' builds.
-            Log.LogMessage(MessageImportance.High, "NuSeal: Invalid arguments for {0}", nameof(ValidateLicenseTask));
+            Log.LogMessage(MessageImportance.High, "NuSeal: Invalid arguments for {0}", nameof(ValidateLicenseTask_0_4_0));
             return true;
         }
 

--- a/tests/NuSeal.Tests/AssetsTests.cs
+++ b/tests/NuSeal.Tests/AssetsTests.cs
@@ -58,7 +58,7 @@ public class AssetsTests : IDisposable
               </ItemGroup>
 
               <UsingTask
-                TaskName="NuSeal.ValidateLicenseTask"
+                TaskName="NuSeal.ValidateLicenseTask_0_4_0"
                 AssemblyFile="$(NuSealAssembly_PrefixPackageId1)"
                 TaskFactory="TaskHostFactory" />
 
@@ -93,7 +93,7 @@ public class AssetsTests : IDisposable
                       AfterTargets="AfterBuild"
                       >
 
-                <NuSeal.ValidateLicenseTask
+                <NuSeal.ValidateLicenseTask_0_4_0
                   MainAssemblyPath="$(TargetPath)"
                   ProtectedPackageId="Prefix.PackageId1"
                   ProtectedAssemblyName="Assembly1"
@@ -135,7 +135,7 @@ public class AssetsTests : IDisposable
                       AfterTargets="AfterBuild"
                       Condition="'$(OutputType)' == 'Exe' Or '$(OutputType)' == 'WinExe' Or '$(MSBuildProjectSdk)' == 'Microsoft.NET.Sdk.Web'">
 
-                <NuSeal.ValidateLicenseTask
+                <NuSeal.ValidateLicenseTask_0_4_0
                   MainAssemblyPath="$(TargetPath)"
                   ProtectedPackageId="Prefix.PackageId1"
                   ProtectedAssemblyName="Assembly1"

--- a/tests/NuSeal.Tests/ConsumerParametersTests.cs
+++ b/tests/NuSeal.Tests/ConsumerParametersTests.cs
@@ -7,7 +7,7 @@ public class ConsumerParametersTests
     {
         var parameters = new ConsumerParameters(
             "path/to/assets",
-            "1.0.0", 
+            "1.0.0",
             "path/to/output",
             "Package.Id",
             "Assembly",
@@ -28,7 +28,7 @@ public class ConsumerParametersTests
         var parameters = new ConsumerParameters(
             "path/to/assets",
             "1.0.0",
-            "path/to/output", 
+            "path/to/output",
             "Package.Id",
             "Assembly",
             Array.Empty<PemData>(),

--- a/tests/NuSeal.Tests/GenerateConsumerAssetsTaskTests.cs
+++ b/tests/NuSeal.Tests/GenerateConsumerAssetsTaskTests.cs
@@ -248,7 +248,7 @@ public class GenerateConsumerAssetsTaskTests : IDisposable
               </ItemGroup>
 
               <UsingTask
-                TaskName="NuSeal.ValidateLicenseTask"
+                TaskName="NuSeal.ValidateLicenseTask_0_4_0"
                 AssemblyFile="$(NuSealAssembly_PrefixPackageId1)"
                 TaskFactory="TaskHostFactory" />
 
@@ -268,7 +268,7 @@ public class GenerateConsumerAssetsTaskTests : IDisposable
                       AfterTargets="AfterBuild"
                       Condition="'$(OutputType)' == 'Exe' Or '$(OutputType)' == 'WinExe' Or '$(MSBuildProjectSdk)' == 'Microsoft.NET.Sdk.Web'">
 
-                <NuSeal.ValidateLicenseTask
+                <NuSeal.ValidateLicenseTask_0_4_0
                   MainAssemblyPath="$(TargetPath)"
                   ProtectedPackageId="Prefix.PackageId1"
                   ProtectedAssemblyName="Assembly1"

--- a/tests/NuSeal.Tests/GlobalUsings.cs
+++ b/tests/NuSeal.Tests/GlobalUsings.cs
@@ -1,4 +1,3 @@
 ﻿global using FluentAssertions;
-global using System.Linq.Expressions;
-global using Xunit;
 global using NuSeal;
+global using Xunit;

--- a/tests/NuSeal.Tests/ValidateLicenseTaskTests_0_4_0.cs
+++ b/tests/NuSeal.Tests/ValidateLicenseTaskTests_0_4_0.cs
@@ -3,14 +3,14 @@ using Microsoft.Build.Utilities;
 
 namespace Tests;
 
-public class ValidateLicenseTaskTests : IDisposable
+public class ValidateLicenseTaskTests_0_4_0 : IDisposable
 {
     private readonly RsaPemPair _rsaPemPair;
     private readonly TestBuildEngine _buildEngine;
     private readonly string _tempDir;
     private readonly string _mainAssemblyPath;
 
-    public ValidateLicenseTaskTests()
+    public ValidateLicenseTaskTests_0_4_0()
     {
         _rsaPemPair = RsaKeyGenerator.GeneratePem();
         _buildEngine = new TestBuildEngine();
@@ -26,7 +26,7 @@ public class ValidateLicenseTaskTests : IDisposable
         var productName = "TestProduct";
         CreateValidLicense(productName);
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -51,7 +51,7 @@ public class ValidateLicenseTaskTests : IDisposable
         var productName = "TestProduct";
         CreateValidLicense(productName);
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -75,7 +75,7 @@ public class ValidateLicenseTaskTests : IDisposable
     {
         var productName = "TestProduct";
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -99,7 +99,7 @@ public class ValidateLicenseTaskTests : IDisposable
     {
         var productName = "TestProduct";
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -124,7 +124,7 @@ public class ValidateLicenseTaskTests : IDisposable
         var productName = "TestProduct";
         CreateValidLicense(productName);
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -158,7 +158,7 @@ public class ValidateLicenseTaskTests : IDisposable
 
         CreateLicense(licenseParameters);
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -192,7 +192,7 @@ public class ValidateLicenseTaskTests : IDisposable
 
         CreateLicense(licenseParameters);
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -226,7 +226,7 @@ public class ValidateLicenseTaskTests : IDisposable
 
         CreateLicense(licenseParameters);
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -260,7 +260,7 @@ public class ValidateLicenseTaskTests : IDisposable
 
         CreateLicense(licenseParameters);
 
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = _mainAssemblyPath,
@@ -282,7 +282,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenNullMainAssemblyPath()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = null!,
@@ -304,7 +304,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenEmptyMainAssemblyPath()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "",
@@ -326,7 +326,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenWhitespaceMainAssemblyPath()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "  ",
@@ -348,7 +348,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenNullProtectedPackageId()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -370,7 +370,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenEmptyProtectedPackageId()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -392,7 +392,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenWhitespaceProtectedPackageId()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -414,7 +414,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenNullProtectedAssemblyName()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -436,7 +436,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenEmptyProtectedAssemblyName()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -458,7 +458,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenWhitespaceProtectedAssemblyName()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -480,7 +480,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenNullPems()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -502,7 +502,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenEmptyPems()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -524,7 +524,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenNullValidationMode()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -546,7 +546,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenEmptyValidationMode()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -568,7 +568,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenWhitespaceValidationMode()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -590,7 +590,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenNullValidationScope()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -612,7 +612,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenEmptyValidationScope()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",
@@ -634,7 +634,7 @@ public class ValidateLicenseTaskTests : IDisposable
     [Fact]
     public void ReturnsTrue_LogsInfo_GivenWhitespaceValidationScope()
     {
-        var task = new ValidateLicenseTask
+        var task = new ValidateLicenseTask_0_4_0
         {
             BuildEngine = _buildEngine,
             MainAssemblyPath = "x",


### PR DESCRIPTION
Fixes #29 

I'm in doubt whether this is a good idea or not, but I have no other solution. There is no way we can use arbitrary names for a task in `UsingTask` and make it unique per version.